### PR TITLE
Start structure for generic report .Rmd

### DIFF
--- a/CCVA_Report.Rmd
+++ b/CCVA_Report.Rmd
@@ -1,0 +1,62 @@
+---
+# pulled this from Amber's climate report .Rmd for us to modify: https://github.com/nationalparkservice/CCRP-Exposure-Reports/blob/main/CCExposure.Rmd
+params:
+  name:
+    label: Park Name # long name for park?
+    value: params$name # park code? not positive how this works
+toc: yes
+toc_depth: 2
+theme: united
+output:
+  word_document:
+    reference_docx: template.docx
+bibliography: ExposureReports.bib
+csl: ecology.csl
+---
+
+```{r setup, include=FALSE}
+# set chunk defaults
+knitr::opts_chunk$set(echo = FALSE,
+                      warning = FALSE,
+                      error = FALSE,
+                      message = FALSE)
+                      
+                      
+# read in libraries
+source("setup.R")
+
+
+# set parameters
+## path to data folder (from project directory)
+path <- "data/"
+## park code for this report
+park <- "BRCA"
+
+
+# read in data
+load(paste0(path, "/", park, "_report_data.RData"))
+
+# match Amber's 'Appendix_Script.R' to create env vars to use for report: https://github.com/nationalparkservice/CCRP-Exposure-Reports/blob/main/Appendix_Script.R
+#source("Appendix-Script.R")
+```
+
+# Report Title
+
+## Key Findings
+
+High level summary of key findings. Metrics such as projected change in runoff, etc.
+
+**Recommended Citation**
+
+\newpage
+
+## Project Background
+
+-   Text describing context for project and climate change at parks 
+
+-   Regional specific expected changes
+
+```{r background_fig}
+
+
+```


### PR DESCRIPTION
Two new files, not much review needed:

- CCVA_Report.Rmd: Just started drafting the structure but didn't get very far. Plan is to model the structure of NPS's climate exposure reporting methods (https://github.com/nationalparkservice/CCRP-Exposure-Reports) and starting moving the CCVA Workflow Outline text from the word doc in our shared docs/ folder
- template.docx: The template doc for rendering reports to Word that NPS used for the climate exposure reports. No edits to this for now.