### PR TITLE
Improvements to `get_wbm_grids` and `get_wbm_aoi`

### DIFF
--- a/Select_GCMs_Centroid.Rmd
+++ b/Select_GCMs_Centroid.Rmd
@@ -521,5 +521,8 @@ parkwide_gcm_clean <- parkwide_gcms %>% map("result") %>%
   compact() %>%
   bind_rows()
 
-write_csv(parkwide_gcm_clean, "data/parkwide_GCMs.csv")
+#write_csv(parkwide_gcm_clean, "data/parkwide_GCMs.csv")
+
+# save new file using filtered WBM GCMs
+write_csv(parkwide_gcm_clean, "data/parkwide_GCMs_WBM_filtered.csv")
 ```

--- a/scratch/explore_wbm_data_pull.Rmd
+++ b/scratch/explore_wbm_data_pull.Rmd
@@ -243,8 +243,9 @@ Version 1 (dplyr) took 15 seconds for one raster. Here trying out `dtplyr`
     
    terra::rast(rast_list) %>%
      terra::as.data.frame(xy = TRUE) %>%
-     dtplyr::lazy_dt() %>%
-     # remove column names that have NA for the data
+     data.table() %>% 
+     #dtplyr::lazy_dt() %>%
+     # remove column names that have NA for the data (this removes the -32767 vals)
      dplyr::select(-contains("_NA")) %>%
      pivot_longer(-(x:y), names_to = "var", values_to = "val") %>%
      # Add historic to name
@@ -273,14 +274,137 @@ Version 1 (dplyr) took 15 seconds for one raster. Here trying out `dtplyr`
                    "accumswe" = "accumswe_in",
                    "soilwater" = "soil_water_in",
                    "Deficit" = "deficit_in")),
-             date = as.Date(date)) 
+             date = as.Date(date))
   }
 ```
 
 Run the function
 ```{r}
-system.time(rast_read(wbm_aoi[1]))
+system.time(test <- rast_read(wbm_aoi[1]))
 
 ```
 
-Cut time down from 15 seconds to 3 seconds per file
+Cut time down from 15 seconds to 3 seconds per file, but brining df back into env takes a while...
+
+Run for all files:
+```{r}
+ wbm_aoi_cleaned <- wbm_aoi %>%
+    purrr::map_dfr(~ rast_read(.)) %>%
+    dplyr::select(-c(x,y)) %>%
+    group_by(date, wbm_var, gcm) %>%
+    summarize_all(.funs = 
+                    list(val = ~ mean(val, na.rm = TRUE)), 
+                  .groups = "keep") %>%
+    pivot_wider(names_from = "wbm_var", values_from = "val") 
+```
+
+
+# Compare dtplyr and data.table()
+
+Dtplyr = 105 seconds
+```{r}
+plan(multisession)
+
+rast_read <- function(rast_list) {
+    
+   terra::rast(rast_list) %>%
+     terra::as.data.frame(xy = TRUE) %>%
+     #data.table() %>% 
+     dtplyr::lazy_dt() %>%
+     # remove column names that have NA for the data (this removes the -32767 vals)
+     dplyr::select(-contains("_NA")) %>%
+     pivot_longer(-(x:y), names_to = "var", values_to = "val") %>%
+     # Add historic to name
+     dplyr::mutate(var =
+                     if_else(
+                       grepl(
+                         '^accumswe|^runoff|^rain|^PET|^AET|^soil_water|^Deficit',
+                         var
+                       ),
+                       paste0("gridmet.historical_", var),
+                       var
+                     ),
+                   val = val / (25.4 * 10)) %>% # 10 = conversion factor, 25.4 = mm to in
+     dplyr::mutate(var = gsub("soil_water", "soilwater", var)) %>%
+      # KEC - separate is VERY slow - can anyone suggest something quicker?
+      separate(var, 
+               into = c("gcm", "wbm_var", "date"), 
+               sep = "_") %>%
+      dplyr::mutate(wbm_var = 
+               str_replace_all(
+                 wbm_var, 
+                 c("runoff" = "runoff_in", 
+                   "rain" = "rain_in", 
+                   "AET" = "aet_in",
+                   "PET" = "pet_in",
+                   "accumswe" = "accumswe_in",
+                   "soilwater" = "soil_water_in",
+                   "Deficit" = "deficit_in")),
+             date = as.Date(date)) %>% 
+    as_tibble()
+}
+
+system.time(test1 <- wbm_aoi %>%
+    furrr::future_map_dfr(~ rast_read(.x)))
+
+```
+
+Data.table = 47 seconds
+```{r}
+plan(multisession)
+
+rast_read <- function(rast_list) {
+    
+   terra::rast(rast_list) %>%
+     terra::as.data.frame(xy = TRUE) %>%
+     data.table() %>% 
+     #dtplyr::lazy_dt() %>%
+     # remove column names that have NA for the data (this removes the -32767 vals)
+     dplyr::select(-contains("_NA")) %>%
+     pivot_longer(-(x:y), names_to = "var", values_to = "val") %>%
+     # Add historic to name
+     dplyr::mutate(var =
+                     if_else(
+                       grepl(
+                         '^accumswe|^runoff|^rain|^PET|^AET|^soil_water|^Deficit',
+                         var
+                       ),
+                       paste0("gridmet.historical_", var),
+                       var
+                     ),
+                   val = val / (25.4 * 10)) %>% # 10 = conversion factor, 25.4 = mm to in
+     dplyr::mutate(var = gsub("soil_water", "soilwater", var)) %>%
+      # KEC - separate is VERY slow - can anyone suggest something quicker?
+      separate(var, 
+               into = c("gcm", "wbm_var", "date"), 
+               sep = "_") %>%
+      dplyr::mutate(wbm_var = 
+               str_replace_all(
+                 wbm_var, 
+                 c("runoff" = "runoff_in", 
+                   "rain" = "rain_in", 
+                   "AET" = "aet_in",
+                   "PET" = "pet_in",
+                   "accumswe" = "accumswe_in",
+                   "soilwater" = "soil_water_in",
+                   "Deficit" = "deficit_in")),
+             date = as.Date(date))
+}
+
+system.time(test2 <- wbm_aoi %>%
+    furrr::future_map_dfr(~ rast_read(.x)))
+```
+
+
+# Test final wbm_aoi function
+
+```{r}
+test <- get_wbm_aoi(park, aoi = watersupply_watershed, aoi_name = "watersupply_watershed", gcm = select_cfs$GCM, aoi_average = FALSE, download = FALSE)
+```
+
+
+
+```{r}
+test_average <- get_wbm_aoi(park, aoi = watersupply_watershed, aoi_name = "watersupply_watershed", gcm = select_cfs$GCM, aoi_average = TRUE, download = FALSE)
+```
+

--- a/scratch/explore_wbm_data_pull.Rmd
+++ b/scratch/explore_wbm_data_pull.Rmd
@@ -43,7 +43,12 @@ get_future_wbm <- function(park, aoi, years, macas, wb_var, path = "data/park/")
   aoi <- st_transform(aoi, crs = "+proj=lcc +lat_0=42.5 +lon_0=-100 +lat_1=25 +lat_2=60 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs")
   
   # download each raster file to temp directory
-  rasters <- map(1:nrow(map_dat), function(x) {
+  
+  ## test using furrr
+  # plan
+  #plan(multisession, workers = parallelly::availableCores() - 1)
+  
+  rasters <- future_map(1:nrow(map_dat), function(x) {
     call <- paste0(
       "/vsicurl/",
       "http://www.yellowstone.solutions/thredds/fileServer/daily_or_monthly/gcm/",
@@ -88,28 +93,28 @@ get_future_wbm <- function(park, aoi, years, macas, wb_var, path = "data/park/")
   # crop to aoi
   final_stack <- terra::crop(final_stack, aoi)
   
-  
+  return(final_stack)
   # save final raster stack to file
-  terra::writeRaster(
-    final_stack,
-    filename = paste0(
-      getwd(),
-      "/",
-      path,
-      "/",
-      park,
-      "/wbm_daily_rasters/",
-      park,
-      "_",
-      wb_var,
-      "_selected_cfs_",
-      years[1],
-      "_",
-      years[length(years)],
-      ".tif"
-    ),
-    overwrite = TRUE
-  )
+  # terra::writeRaster(
+  #   final_stack,
+  #   filename = paste0(
+  #     getwd(),
+  #     "/",
+  #     path,
+  #     "/",
+  #     park,
+  #     "/wbm_daily_rasters/",
+  #     park,
+  #     "_",
+  #     wb_var,
+  #     "_selected_cfs_",
+  #     years[1],
+  #     "_",
+  #     years[length(years)],
+  #     ".tif"
+  #   ),
+  #   overwrite = TRUE
+  # )
   
 }
 ```
@@ -146,31 +151,70 @@ daily_runoff <- rast("data/park/BRCA/wbm_daily_rasters/BRCA_runoff_selected_cfs_
 
 
 # Run function for full park data
+Testing out adding `future_map()` to the function cut it down by 1 minute.
 
 ```{r}
+plan(multisession, workers = parallelly::availableCores() - 1)
+
 start <- Sys.time()
 
-walk(
-  c(
-    #"soil_water",
-    "runoff"
+#walk(
+test <- future_map(
+  c(#"soil_water",
+    "runoff"),
     #"rain",
     #"accumswe",
     #"PET",
     #"Deficit",
-    #"AET"
-  ),
-  ~ get_future_wbm(
-    park = park,
-    aoi = st_buffer(park_boundary, 20000),
-    years = 2023:2070,
-    wb_var = .x,
-    macas = select_cfs$GCM
+    #"AET"),
+    ~ get_future_wbm(
+      park = park,
+      aoi = st_buffer(park_boundary, 20000),
+      years = 2023:2070,
+      wb_var = .x,
+      macas = select_cfs$GCM
+    )
   )
-)
 
+  
 end <- Sys.time()
 
 end - start
+```
+
+# Parallelize it with `furrr`
+Still takes a while...not seeing any improvement.
+
+```{r}
+library(furrr)
+library(tictoc)
+
+# plan
+plan(multisession, workers = parallelly::availableCores() - 1)
+
+tic()
+
+future_walk(
+      c(
+        #"soil_water",
+        "runoff",
+        "rain"
+        #"accumswe",
+        #"PET",
+        #"Deficit",
+        #"AET"
+      ),
+      ~ get_wbm_grids(
+        park = park,
+        aoi_name = "test_furrr",
+        aoi = aoi,
+        wb_var = .x,
+        macas = select_cfs$GCM,
+        path = path
+      )
+    )
+
+toc()
+
 ```
 

--- a/scratch/explore_wbm_data_pull.Rmd
+++ b/scratch/explore_wbm_data_pull.Rmd
@@ -183,7 +183,7 @@ end - start
 ```
 
 # Parallelize it with `furrr`
-Still takes a while...not seeing any improvement.
+
 
 ```{r}
 library(furrr)
@@ -206,8 +206,8 @@ future_walk(
       ),
       ~ get_wbm_grids(
         park = park,
-        aoi_name = "test_furrr",
-        aoi = aoi,
+        aoi_name = "test_furrr_2",
+        aoi = watersupply_watershed,
         wb_var = .x,
         macas = select_cfs$GCM,
         path = path
@@ -215,6 +215,9 @@ future_walk(
     )
 
 toc()
+
+# sets processing back to default
+plan(sequential)
 
 ```
 

--- a/scratch/explore_wbm_data_pull.Rmd
+++ b/scratch/explore_wbm_data_pull.Rmd
@@ -183,7 +183,7 @@ end - start
 ```
 
 # Parallelize it with `furrr`
-
+Cut the time down to 32 minutes (from ~70)
 
 ```{r}
 library(furrr)
@@ -196,13 +196,13 @@ tic()
 
 future_walk(
       c(
-        #"soil_water",
+        "soil_water",
         "runoff",
-        "rain"
-        #"accumswe",
-        #"PET",
-        #"Deficit",
-        #"AET"
+        "rain",
+        "accumswe",
+        "PET",
+        "Deficit",
+        "AET"
       ),
       ~ get_wbm_grids(
         park = park,
@@ -211,7 +211,8 @@ future_walk(
         wb_var = .x,
         macas = select_cfs$GCM,
         path = path
-      )
+      ),
+      .progress = TRUE
     )
 
 toc()
@@ -221,3 +222,65 @@ plan(sequential)
 
 ```
 
+# Cleaning outputs for `get_wbm_aoi`
+
+Test use of `dtplyr` over `dplyr`
+
+```{r}
+# list of rasters
+wbm_aoi <- list.files("data/park/BRCA/wbm_daily_rasters/",full.names = TRUE) %>% 
+            grep("watersupply_watershed", ., value=TRUE) 
+
+
+```
+
+rast_read function:
+
+Version 1 (dplyr) took 15 seconds for one raster. Here trying out `dtplyr`
+
+```{r}
+ rast_read <- function(rast_list) {
+    
+   terra::rast(rast_list) %>%
+     terra::as.data.frame(xy = TRUE) %>%
+     dtplyr::lazy_dt() %>%
+     # remove column names that have NA for the data
+     dplyr::select(-contains("_NA")) %>%
+     pivot_longer(-(x:y), names_to = "var", values_to = "val") %>%
+     # Add historic to name
+     dplyr::mutate(var =
+                     if_else(
+                       grepl(
+                         '^accumswe|^runoff|^rain|^PET|^AET|^soil_water|^Deficit',
+                         var
+                       ),
+                       paste0("gridmet.historical_", var),
+                       var
+                     ),
+                   val = val / (25.4 * 10)) %>% # 10 = conversion factor, 25.4 = mm to in
+     dplyr::mutate(var = gsub("soil_water", "soilwater", var)) %>%
+      # KEC - separate is VERY slow - can anyone suggest something quicker?
+      separate(var, 
+               into = c("gcm", "wbm_var", "date"), 
+               sep = "_") %>%
+      dplyr::mutate(wbm_var = 
+               str_replace_all(
+                 wbm_var, 
+                 c("runoff" = "runoff_in", 
+                   "rain" = "rain_in", 
+                   "AET" = "aet_in",
+                   "PET" = "pet_in",
+                   "accumswe" = "accumswe_in",
+                   "soilwater" = "soil_water_in",
+                   "Deficit" = "deficit_in")),
+             date = as.Date(date)) 
+  }
+```
+
+Run the function
+```{r}
+system.time(rast_read(wbm_aoi[1]))
+
+```
+
+Cut time down from 15 seconds to 3 seconds per file

--- a/setup.R
+++ b/setup.R
@@ -49,7 +49,8 @@ packages <- c(
   "tmap", 
   "maptiles",
   "flextable", 
-  "ggseas"
+  "ggseas",
+  "furrr"
   )
 
 

--- a/setup.R
+++ b/setup.R
@@ -50,7 +50,8 @@ packages <- c(
   "maptiles",
   "flextable", 
   "ggseas",
-  "furrr"
+  "furrr",
+  "dtplyr"
   )
 
 

--- a/src/get_wbm_aoi.R
+++ b/src/get_wbm_aoi.R
@@ -22,7 +22,7 @@ get_wbm_aoi <- function(park, aoi, aoi_name, gcm = select_cfs$GCM, download = FA
   if (download == TRUE) {
     print("Downloading gridded WBM. This may take several minutes to hours...\n\n")
     
-    walk(
+    furrr::future_walk(
       c(
         "soil_water",
         "runoff",
@@ -45,50 +45,56 @@ get_wbm_aoi <- function(park, aoi, aoi_name, gcm = select_cfs$GCM, download = FA
     print("Download complete!\n\n")
   }
   
-  wbm_ws_dir <- paste0(path,park,"/wbm_daily_rasters/")
+  wbm_aoi_dir <- paste0(path,park,"/wbm_daily_rasters/")
   
   rast_read <- function(rast_list) {
     
-    rast(rast_list) %>% 
-      as.data.frame(., xy = TRUE) %>%
-      pivot_longer(-(x:y),
-                   names_to = "var",
-                   values_to = "val") %>%
+    terra::rast(rast_list) %>%
+      terra::as.data.frame(xy = TRUE) %>%
+      dtplyr::lazy_dt() %>%
+      # remove column names that have NA for the data
+      dplyr::select(-contains("_NA")) %>%
+      pivot_longer(-(x:y), names_to = "var", values_to = "val") %>%
       # Add historic to name
-      mutate(var = 
-               ifelse(
-                 grepl('^accumswe|^runoff|^rain|^PET|^AET|^soil_water|^Deficit', var),
-                 paste0("gridmet.historical_",var),var),
-             val = val / (25.4*10) ) %>% # 10 = conversion factor, 25.4 = mm to in
-      mutate(var = gsub("soil_water", "soilwater", var)) %>%
+      dplyr::mutate(var =
+                      if_else(
+                        grepl(
+                          '^accumswe|^runoff|^rain|^PET|^AET|^soil_water|^Deficit',
+                          var
+                        ),
+                        paste0("gridmet.historical_", var),
+                        var
+                      ),
+                    val = val / (25.4 * 10)) %>% # 10 = conversion factor, 25.4 = mm to in
+      dplyr::mutate(var = gsub("soil_water", "soilwater", var)) %>%
       # KEC - separate is VERY slow - can anyone suggest something quicker?
       separate(var, 
                into = c("gcm", "wbm_var", "date"), 
                sep = "_") %>%
-      mutate(wbm_var = 
-               str_replace_all(
-                 wbm_var, 
-                 c("runoff" = "runoff_in", 
-                   "rain" = "rain_in", 
-                   "AET" = "aet_in",
-                   "PET" = "pet_in",
-                   "accumswe" = "accumswe_in",
-                   "soilwater" = "soil_water_in",
-                   "Deficit" = "deficit_in")),
-             date = as.Date(date)) 
+      dplyr::mutate(wbm_var = 
+                      str_replace_all(
+                        wbm_var, 
+                        c("runoff" = "runoff_in", 
+                          "rain" = "rain_in", 
+                          "AET" = "aet_in",
+                          "PET" = "pet_in",
+                          "accumswe" = "accumswe_in",
+                          "soilwater" = "soil_water_in",
+                          "Deficit" = "deficit_in")),
+                    date = as.Date(date)) 
   }
   
   
-  ws_wbm <- list.files(wbm_ws_dir,full.names = TRUE) %>% 
+  wbm_aoi <- list.files(wbm_aoi_dir,full.names = TRUE) %>% 
             grep(aoi_name, ., value=TRUE) 
   
-  if (length(ws_wbm) < 1) {
+  if (length(wbm_aoi) < 1) {
     
     stop("Must download wbm files first! Try function argument: download = TRUE.")
   
     } else {
     
-    ws_wbm <- ws_wbm %>%
+    wbm_aoi <- wbm_aoi %>%
     purrr::map_dfr(~ rast_read(.)) %>%
     dplyr::select(-c(x,y)) %>%
     group_by(date, wbm_var, gcm) %>%

--- a/src/get_wbm_aoi.R
+++ b/src/get_wbm_aoi.R
@@ -11,13 +11,20 @@
 #' @param aoi_name A character string used to name the file, often a description of the AOI pulled
 #' @param gcm A character vector containing selected GCMs for which to download future WBM
 #' @param download A TRUE/FALSE
+#' @param aoi_average TRUE/FALSE whether to return a single daily average value for the entire aoi
 #' @param path home path in which to create subfolder
 #' 
 #' @return A data.frame containing daily timeseries of the spatial mean for 
 #'          each water balance variable formatted like the 
 #'          get_centroid_wbm_data output.
 
-get_wbm_aoi <- function(park, aoi, aoi_name, gcm = select_cfs$GCM, download = FALSE, path = "data/park/") {
+get_wbm_aoi <- function(park,
+                        aoi,
+                        aoi_name,
+                        gcm = select_cfs$GCM,
+                        download = FALSE,
+                        aoi_average = FALSE,
+                        path = "data/park/") {
   
   if (download == TRUE) {
     print("Downloading gridded WBM. This may take several minutes to hours...\n\n")
@@ -45,13 +52,16 @@ get_wbm_aoi <- function(park, aoi, aoi_name, gcm = select_cfs$GCM, download = FA
     print("Download complete!\n\n")
   }
   
+  # set up directory with wbm rasters
   wbm_aoi_dir <- paste0(path,park,"/wbm_daily_rasters/")
   
+  # create function to clean and convert wbm rasters to data frame
   rast_read <- function(rast_list) {
     
     terra::rast(rast_list) %>%
       terra::as.data.frame(xy = TRUE) %>%
-      dtplyr::lazy_dt() %>%
+      # convert to data.table for speed
+      data.table() %>% 
       # remove column names that have NA for the data
       dplyr::select(-contains("_NA")) %>%
       pivot_longer(-(x:y), names_to = "var", values_to = "val") %>%
@@ -67,7 +77,6 @@ get_wbm_aoi <- function(park, aoi, aoi_name, gcm = select_cfs$GCM, download = FA
                       ),
                     val = val / (25.4 * 10)) %>% # 10 = conversion factor, 25.4 = mm to in
       dplyr::mutate(var = gsub("soil_water", "soilwater", var)) %>%
-      # KEC - separate is VERY slow - can anyone suggest something quicker?
       separate(var, 
                into = c("gcm", "wbm_var", "date"), 
                sep = "_") %>%
@@ -84,27 +93,39 @@ get_wbm_aoi <- function(park, aoi, aoi_name, gcm = select_cfs$GCM, download = FA
                     date = as.Date(date)) 
   }
   
-  
+  # list all aoi wbm rasters
   wbm_aoi <- list.files(wbm_aoi_dir,full.names = TRUE) %>% 
             grep(aoi_name, ., value=TRUE) 
+  
   
   if (length(wbm_aoi) < 1) {
     
     stop("Must download wbm files first! Try function argument: download = TRUE.")
   
-    } else {
-    
-    wbm_aoi <- wbm_aoi %>%
-    purrr::map_dfr(~ rast_read(.)) %>%
-    dplyr::select(-c(x,y)) %>%
-    group_by(date, wbm_var, gcm) %>%
-    summarize_all(.funs = 
-                    list(val = ~ mean(val, na.rm = TRUE)), 
-                  .groups = "keep") %>%
-    pivot_wider(names_from = "wbm_var", values_from = "val") 
-  
-    return(ws_wbm)
-    
     }
+    
+  if(aoi_average == TRUE) {
+    
+    wbm_aoi_cleaned <- wbm_aoi %>%
+      furrr::future_map_dfr(~ rast_read(.)) %>%
+      dplyr::select(-c(x,y)) %>%
+      group_by(date, wbm_var, gcm) %>%
+      summarize_all(.funs = 
+                      list(val = ~ mean(val, na.rm = TRUE)), 
+                    .groups = "keep") %>%
+      pivot_wider(names_from = "wbm_var", values_from = "val") %>% 
+      ungroup()
+    
+  } else {
+    
+    wbm_aoi_cleaned <- wbm_aoi %>%
+      furrr::future_map_dfr(~ rast_read(.))
+    
+  }
+  
+  
+    return(wbm_aoi_cleaned)
+    
+    
   
 }

--- a/src/get_wbm_grids.R
+++ b/src/get_wbm_grids.R
@@ -22,8 +22,8 @@ get_wbm_grids <- function(park,
                           macas, #= selected_GCMs[c(1,4),]$GCM, 
                           wb_var, #= "runoff", 
                           path = "data/park/") {
-  start <- Sys.time()
-  # check that path to save files to exists
+
+    # check that path to save files to exists
   if (!dir.exists(paste0(getwd(), "/", path, "/", park))) {
     dir.create(file.path(paste0(
       getwd(), "/", path, "/", park
@@ -44,7 +44,7 @@ get_wbm_grids <- function(park,
   aoi <- st_transform(aoi, crs = "+proj=lcc +lat_0=42.5 +lon_0=-100 +lat_1=25 +lat_2=60 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs")
   
   # download each raster file to temp directory
-  future_rasters <- map(1:nrow(map_dat), function(x) {
+  future_rasters <- future_map(1:nrow(map_dat), function(x) {
     call <- paste0(
       "/vsicurl/",
       "http://www.yellowstone.solutions/thredds/fileServer/daily_or_monthly/gcm/",
@@ -113,7 +113,7 @@ get_wbm_grids <- function(park,
   aoi <- st_transform(aoi, crs = "+proj=lcc +lat_0=42.5 +lon_0=-100 +lat_1=25 +lat_2=60 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs")
   
   # download each raster file to temp directory
-  historic_rasters <- map(1:nrow(map_dat), function(x) {
+  historic_rasters <- future_map(1:nrow(map_dat), function(x) {
     call <- paste0(
       "/vsicurl/",
       "http://www.yellowstone.solutions/thredds/fileServer/daily_or_monthly/v2_historical/gridmet_v_1_5_historical/V_1_5_",
@@ -168,10 +168,7 @@ get_wbm_grids <- function(park,
     overwrite = TRUE
   )
   
-  end <- Sys.time()
-  
-  end - start
-  
+
   return(list("future" = final_future_stack, "historic" = final_historic_stack))
   
 }

--- a/src/get_wbm_grids.R
+++ b/src/get_wbm_grids.R
@@ -44,7 +44,7 @@ get_wbm_grids <- function(park,
   aoi <- st_transform(aoi, crs = "+proj=lcc +lat_0=42.5 +lon_0=-100 +lat_1=25 +lat_2=60 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs")
   
   # download each raster file to temp directory
-  future_rasters <- future_map(1:nrow(map_dat), function(x) {
+  future_rasters <- furrr::future_map(1:nrow(map_dat), function(x) {
     call <- paste0(
       "/vsicurl/",
       "http://www.yellowstone.solutions/thredds/fileServer/daily_or_monthly/gcm/",
@@ -113,7 +113,7 @@ get_wbm_grids <- function(park,
   aoi <- st_transform(aoi, crs = "+proj=lcc +lat_0=42.5 +lon_0=-100 +lat_1=25 +lat_2=60 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs")
   
   # download each raster file to temp directory
-  historic_rasters <- future_map(1:nrow(map_dat), function(x) {
+  historic_rasters <- furrr::future_map(1:nrow(map_dat), function(x) {
     call <- paste0(
       "/vsicurl/",
       "http://www.yellowstone.solutions/thredds/fileServer/daily_or_monthly/v2_historical/gridmet_v_1_5_historical/V_1_5_",


### PR DESCRIPTION
Two main additions here are related to parallellization with `furrr` and data frame manipulation with `data.table`. Two files edited:

- `get_wbm_grids()`: For both future and historic grids I changed `purrr::map()` to `furrr::future_map()`. **Note:** In order for `furrr` functions to improve speed we need to run `plan(multisession)` at the beginning of the report/workflow (cannot add `plan()` within a function). I am a bit hesitant to hardcode it into the `setup.R` script because we don't necessarily *always* want to be running code in parallel....often workflows I've seen will revert back to default processing with `plan(sequential)` after running `furrr` functions. Maybe a point of discussion though.
- `get_wbm_aoi()`: Implemented `furrr` wherever we were previously mapping. Added use of `data.table()` to speed up raster to data frame cleaning. Added an argument for whether we want to return daily values for all pixels or a single daily averaged value for the aoi.

Other notes:
- `explore_wbm_data_pull.Rmd`: This is my scratch file for testing, but at the bottom you can see some testing/benchmarking for using `furrr` and comparing `data.table` to `dtplyr`. `dtplyr` processing is wayyyy faster but bringing the big data frame back in to the environment takes a while. I think this would only be advantageous when the final cleaned data frame is much smaller (so conversion at the end is quick).
- `setup.R`: I added the `furrr` and `dtplyr` packages.

